### PR TITLE
Enable to access without Github API Token

### DIFF
--- a/src/test/githubclient.test.ts
+++ b/src/test/githubclient.test.ts
@@ -14,7 +14,7 @@ suite("GithubClient Tests", () => {
         assert.ok(new GithubClient());
 
         stub.onCall(tokenIndex++).returns("");
-        assert.throws(() => { return new GithubClient(); }, Error);
+        assert.ok(new GithubClient());
     });
 
     test("getFullRepositoryName", () => {


### PR DESCRIPTION
When access to a public repository, API Token isn't needed.

To increase more users.

Fix #15 